### PR TITLE
Enable list task command with [all] option

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -57,31 +57,31 @@ Examples:
 
 
 #### Listing tasks
-Shows a list of all tasks that are marked done. <br>
-Format: `list task [all]`
+Shows a list of tasks that are not marked done. <br>
+Format: `list -t [-a]`
 
 > Tasks that are marked done will not be shown by default.
 > An [all] optional flag will request the TaskBook to list all tasks, both marked done and not yet marked done. 
 
 Examples: 
-* `list task`  
+* `list -t`  
   Lists tasks that are not marked done.
-* `list task all`  
+* `list -t -a`  
   All tasks will be shown.
 
 
 #### Listing event
-Shows a list of all tasks that are marked done. <br>
-Format: `list task [all]`
+Shows a list of all events that are completed. <br>
+Format: `list -e [-a]`
 
-> Tasks that are marked done will not be shown by default.
-> An [all] optional flag will request the TaskBook to list all tasks, both marked done and not yet marked done. 
+> Events that are completed will not be shown by default.
+> An [-a] optional flag will request the TaskBook to list all events, both completed  and passed. 
 
 Examples: 
-* `list task `<br>
-  Lists tasks that are not marked done.
-* `list task all` <br>
-  All tasks will be shown.
+* `list -t `<br>
+  Lists events that are not completed yet. 
+* `list -t -a` <br>
+  All events will be shown.
 
 
 

--- a/src/main/java/seedu/task/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/task/logic/commands/AddTaskCommand.java
@@ -20,6 +20,8 @@ public class AddTaskCommand extends Command {
 	public static final String MESSAGE_SUCCESS = "New task added: %1$s";
 	public static final String MESSAGE_DUPLICATE_TASK = "This task already exists in the task book";
 
+	private static final Boolean DEFAULT_STATUS = false;
+
 	private final Task toAdd;
 
 	/**
@@ -30,8 +32,9 @@ public class AddTaskCommand extends Command {
 	 * @throws IllegalValueException
 	 *             if any of the raw values are invalid
 	 */
+
 	public AddTaskCommand(String name, String description) throws IllegalValueException {
-		this.toAdd = new Task(new Name(name), new Description(description)); //TODO: more flexible of tasks type
+		this.toAdd = new Task(new Name(name), new Description(description), DEFAULT_STATUS); //TODO: more flexible of tasks type
 	}
 
 	@Override

--- a/src/main/java/seedu/task/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/task/logic/commands/ListCommand.java
@@ -1,20 +1,26 @@
 package seedu.task.logic.commands;
 
-
 /**
- * Lists all persons in the address book to the user.
+ * Abstract class to represent generic list operations.  
+ * @author xuchen
  */
-public class ListCommand extends Command {
-
-    public static final String COMMAND_WORD = "list";
-
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
-
-    public ListCommand() {}
-
-    @Override
-    public CommandResult execute() {
-        model.updateFilteredListToShowAll();
-        return new CommandResult(MESSAGE_SUCCESS);
-    }
+public abstract class ListCommand extends Command {
+	public static final String COMMAND_WORD = "list";
+	
+	/** fields to indicate if all items should be displayed **/
+	protected boolean showAll;
+	
+	/**
+	 * Executes the command and returns the result message.
+	 * @return feedback message of the operation result for display
+	 */
+	public abstract CommandResult execute();
+	
+	/**
+	 * Determine if the list operations should show all items. 
+	 * @return if all items should be shown
+	 */
+	protected boolean shouldShowAll() {
+		return this.showAll;
+	}
 }

--- a/src/main/java/seedu/task/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/task/logic/commands/ListCommand.java
@@ -7,6 +7,13 @@ package seedu.task.logic.commands;
 public abstract class ListCommand extends Command {
 	public static final String COMMAND_WORD = "list";
 	
+	public static final String MESSAGE_USAGE = COMMAND_WORD + " -t : Shows a list of tasks that are not marked done\n"
+			+ COMMAND_WORD + " -e : Shows a list of events that are not completed yet.\n "
+			+ "Optional flag: [-a] to request show all tasks" 
+			+ "Parameters: LIST_TYPE + [OPTION_ALL]\n" 
+			+ "Example: "+ COMMAND_WORD + " -t -a";
+
+	
 	/** fields to indicate if all items should be displayed **/
 	protected boolean showAll;
 	

--- a/src/main/java/seedu/task/logic/commands/ListTaskCommand.java
+++ b/src/main/java/seedu/task/logic/commands/ListTaskCommand.java
@@ -1,0 +1,39 @@
+package seedu.task.logic.commands;
+
+
+/**
+ * Lists all persons in the address book to the user.
+ */
+public class ListTaskCommand extends ListCommand {
+
+	public static final String MESSAGE_INCOMPLETED_SUCCESS = "Listed undone tasks";
+	public static final String MESSAGE_ALL_SUCCESS = "Listed all tasks";
+	
+	public static final String MESSAGE_USAGE = COMMAND_WORD + " -t : Shows a list of tasks that are not marked done\n"
+			+ "Optional flag: [-a] to request show all tasks" + "Parameters: LIST_TYPE + [OPTION_ALL]\n" + "Example: "
+			+ COMMAND_WORD + " -t -a";
+
+	private static final boolean STATUS_INCOMPLETED = false;
+
+	
+
+	public ListTaskCommand(boolean showAll) {
+		this.showAll = showAll;
+	}
+	
+	@Override
+	/**
+	 * Executes a list task operation and updates the model
+	 * 
+	 * @return successful command execution feedback to user
+	 */
+	public CommandResult execute() {
+		if (!shouldShowAll()) {
+			model.updateFilteredTaskListToShowWithStatus(STATUS_INCOMPLETED);
+			return new CommandResult(MESSAGE_INCOMPLETED_SUCCESS);
+		} else {
+			model.updateFilteredListToShowAll();
+			return new CommandResult(MESSAGE_ALL_SUCCESS);
+		}
+	}
+}

--- a/src/main/java/seedu/task/logic/commands/ListTaskCommand.java
+++ b/src/main/java/seedu/task/logic/commands/ListTaskCommand.java
@@ -9,13 +9,7 @@ public class ListTaskCommand extends ListCommand {
 	public static final String MESSAGE_INCOMPLETED_SUCCESS = "Listed undone tasks";
 	public static final String MESSAGE_ALL_SUCCESS = "Listed all tasks";
 	
-	public static final String MESSAGE_USAGE = COMMAND_WORD + " -t : Shows a list of tasks that are not marked done\n"
-			+ "Optional flag: [-a] to request show all tasks" + "Parameters: LIST_TYPE + [OPTION_ALL]\n" + "Example: "
-			+ COMMAND_WORD + " -t -a";
-
 	private static final boolean STATUS_INCOMPLETED = false;
-
-	
 
 	public ListTaskCommand(boolean showAll) {
 		this.showAll = showAll;

--- a/src/main/java/seedu/task/logic/parser/ListParser.java
+++ b/src/main/java/seedu/task/logic/parser/ListParser.java
@@ -1,0 +1,33 @@
+package seedu.task.logic.parser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import static seedu.taskcommons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import seedu.task.logic.commands.Command;
+import seedu.task.logic.commands.IncorrectCommand;
+import seedu.task.logic.commands.ListTaskCommand;
+
+public class ListParser implements Parser {
+
+	private static final Pattern LIST_ARGS_FORMAT = Pattern.compile("(?<type>-t|-e)" + "(?: (?<showAll>-a))*");
+	private static final String LIST_TYPE_TASK = "-t";
+
+	@Override
+	public Command prepare(String args) {
+		final Matcher matcher = LIST_ARGS_FORMAT.matcher(args.trim());
+
+		if (!matcher.matches()) {
+			return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListTaskCommand.MESSAGE_USAGE));
+		}
+
+		boolean showAll = (matcher.group("showAll") == null) ? false : true;
+
+		switch (matcher.group("type")) {
+		case LIST_TYPE_TASK:
+			return new ListTaskCommand(showAll);
+		default:
+			return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListTaskCommand.MESSAGE_USAGE));
+		}
+	}
+
+}

--- a/src/main/java/seedu/task/logic/parser/ParserManager.java
+++ b/src/main/java/seedu/task/logic/parser/ParserManager.java
@@ -42,7 +42,7 @@ public class ParserManager {
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
-
+        
         case AddTaskCommand.COMMAND_WORD:
             return new AddParser().prepare(arguments);
 
@@ -59,8 +59,8 @@ public class ParserManager {
             return prepareFind(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
-
+            return new ListParser().prepare(arguments);
+            
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
 

--- a/src/main/java/seedu/task/model/Model.java
+++ b/src/main/java/seedu/task/model/Model.java
@@ -40,5 +40,8 @@ public interface Model {
 
     /** Updates the filter of the filtered task list to filter by the given keywords*/
     void updateFilteredTaskList(Set<String> keywords);
+    
+    /** Updates the filter of the filtered task list to filter by the status*/
+    void updateFilteredTaskListToShowWithStatus(boolean status);
 
 }

--- a/src/main/java/seedu/task/model/ModelManager.java
+++ b/src/main/java/seedu/task/model/ModelManager.java
@@ -114,6 +114,12 @@ public class ModelManager extends ComponentManager implements Model {
     private void updateFilteredTaskList(Expression expression) {
         filteredTasks.setPredicate(expression::satisfies);
     }
+    
+    @Override
+	public void updateFilteredTaskListToShowWithStatus(boolean status) {
+		updateFilteredTaskList(new PredicateExpression(new StatusQualifier(status)));
+		
+	}
 
     //========== Inner classes/interfaces used for filtering ==================================================
 
@@ -166,6 +172,23 @@ public class ModelManager extends ComponentManager implements Model {
             return "task=" + String.join(", ", taskKeyWords);
         }
     }
-
-
+    
+    private class StatusQualifier implements Qualifier {
+    	private Boolean status;
+    	
+    	StatusQualifier(boolean status){
+    		this.status = status;
+    	}
+    	
+		@Override
+		public boolean run(ReadOnlyTask task) {
+			return task.getTaskStatus() == status;
+		}
+		
+		@Override 
+		public String toString() {
+			return "task is" + (status ? "completed" : "not yet completed");  
+		}
+    	
+    }
 }

--- a/src/main/java/seedu/task/model/item/Task.java
+++ b/src/main/java/seedu/task/model/item/Task.java
@@ -18,9 +18,9 @@ public class Task implements ReadOnlyTask {
     /**
      * Every field must be present and not null.
      */
-    public Task(Name name, Description description) {
-    	this(name, description,false);    
-    }
+//    public Task(Name name, Description description) {
+//    	this(name, description,false);    
+//    }
     
     public Task(Name name, Description description, Boolean status) {
         assert !CollectionUtil.isAnyNull(name, description);
@@ -34,7 +34,7 @@ public class Task implements ReadOnlyTask {
      * Copy constructor.
      */
     public Task(ReadOnlyTask source) {
-        this(source.getTask(), source.getDescription());
+        this(source.getTask(), source.getDescription(), source.getTaskStatus());
     }
 
     @Override
@@ -55,6 +55,10 @@ public class Task implements ReadOnlyTask {
     @Override
     public Boolean getTaskStatus() {
         return isTaskCompleted;
+    }
+    
+    public void setCompleted() {
+    	isTaskCompleted = !isTaskCompleted;
     }
 
     @Override

--- a/src/test/java/guitests/ListCommandTest.java
+++ b/src/test/java/guitests/ListCommandTest.java
@@ -1,0 +1,10 @@
+package guitests;
+
+import org.junit.Test;
+import seedu.task.testutil.TestTask;
+import seedu.taskcommons.core.Messages;
+import static org.junit.Assert.assertTrue;
+
+public class ListCommandTest extends TaskBookGuiTest {
+
+}

--- a/src/test/java/seedu/task/testutil/TestUtil.java
+++ b/src/test/java/seedu/task/testutil/TestUtil.java
@@ -64,15 +64,15 @@ public class TestUtil {
     private static Task[] getSampleTaskData() {
         try {
             return new Task[]{
-                    new Task(new Name("CS1010 CodeCrunch Practices"), new Description("20 Practices up to Lecture 7 syllabus")),
-                    new Task(new Name("CS1020 CodeCrunch Practices"), new Description("20 Practices up to Lecture 7 syllabus")),
-                    new Task(new Name("Computing Project 1"), new Description("Complete my part before meeting")),
-                    new Task(new Name("Science Project 1"), new Description("Complete my part before meeting")),
-                    new Task(new Name("Biz Project 1"), new Description("Complete my part before meeting")),
-                    new Task(new Name("Engineering Project 1"), new Description("Complete my part before meeting")),
-                    new Task(new Name("Music Project 1"), new Description("Complete my part before meeting")),
-                    new Task(new Name("Arts Project 1"), new Description("Complete my part before meeting")),
-                    new Task(new Name("Social Science Project 1"), new Description("Complete my part before meeting")),
+                    new Task(new Name("CS1010 CodeCrunch Practices"), new Description("20 Practices up to Lecture 7 syllabus"), false),
+                    new Task(new Name("CS1020 CodeCrunch Practices"), new Description("20 Practices up to Lecture 7 syllabus"), false),
+                    new Task(new Name("Computing Project 1"), new Description("Complete my part before meeting"), false),
+                    new Task(new Name("Science Project 1"), new Description("Complete my part before meeting"), false),
+                    new Task(new Name("Biz Project 1"), new Description("Complete my part before meeting"),false),
+                    new Task(new Name("Engineering Project 1"), new Description("Complete my part before meeting"), false),
+                    new Task(new Name("Music Project 1"), new Description("Complete my part before meeting"),false),
+                    new Task(new Name("Arts Project 1"), new Description("Complete my part before meeting"),false),
+                    new Task(new Name("Social Science Project 1"), new Description("Complete my part before meeting"),false),
             };
         } catch (IllegalValueException e) {
             assert false;


### PR DESCRIPTION
### Context

Enable list tasks operations with the option to request either unmarked tasks or all tasks
- Passed unit testing
- Change the Task constructor to include status. Now a task can only be initiated in the following method:
  `Task aTask = new Task(name, description, status)`
  This is to allow TaskBook to be copied with status of its Tasks.  Please refer to TaskBook.reset() method.
### Links
#26
### Reviewers

@CS2103AUG2016-F09-C4/developers 
