### PR TITLE
Implement find for both events and tasks

### DIFF
--- a/src/main/java/seedu/task/logic/commands/Command.java
+++ b/src/main/java/seedu/task/logic/commands/Command.java
@@ -12,15 +12,25 @@ public abstract class Command {
     protected Model model;
 
     /**
-     * Constructs a feedback message to summarise an operation that displayed a listing of persons.
+     * Constructs a feedback message to summarise an operation that displayed a listing of tasks.
      *
      * @param displaySize used to generate summary
-     * @return summary message for persons displayed
+     * @return summary message for tasks displayed
      */
     public static String getMessageForTaskListShownSummary(int displaySize) {
         return String.format(Messages.MESSAGE_TASKS_LISTED_OVERVIEW, displaySize);
     }
 
+    /**
+     * Constructs a feedback message to summarise an operation that displayed a listing of events.
+     *
+     * @param displaySize used to generate summary
+     * @return summary message for events displayed
+     */
+    public static String getMessageForEventListShownSummary(int displaySize) {
+        return String.format(Messages.MESSAGE_EVENTS_LISTED_OVERVIEW, displaySize);
+    }
+    
     /**
      * Executes the command and returns the result message.
      *

--- a/src/main/java/seedu/task/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/task/logic/commands/FindCommand.java
@@ -1,5 +1,6 @@
 package seedu.task.logic.commands;
 
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -10,10 +11,12 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all tasks and events whose names and descriptions contain any of "
             + "the specified keywords (case-sensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Example: " + COMMAND_WORD + " CS2103 Project";
+
+	private static final String MESSAGE_SUCCESS_FIND = "%1$s\n%2$s";
 
     private final Set<String> keywords;
 
@@ -24,7 +27,13 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute() {
         model.updateFilteredTaskList(keywords);
-        return new CommandResult(getMessageForTaskListShownSummary(model.getFilteredTaskList().size()));
+        model.updateFilteredEventList(keywords);
+        
+        //TODO: check on coding convention
+        return new CommandResult(String.format(MESSAGE_SUCCESS_FIND, 
+        		getMessageForTaskListShownSummary(model.getFilteredTaskList().size()),
+        		getMessageForEventListShownSummary(model.getFilteredEventList().size()))
+        		);
     }
 
 }

--- a/src/main/java/seedu/task/logic/parser/ParserManager.java
+++ b/src/main/java/seedu/task/logic/parser/ParserManager.java
@@ -22,8 +22,7 @@ public class ParserManager {
 
     private static final Pattern ITEM_INDEX_ARGS_FORMAT = Pattern.compile("(?<targetIndex>.+)");
 
-    private static final Pattern KEYWORDS_ARGS_FORMAT =
-            Pattern.compile("(?<keywords>\\S+(?:\\s+\\S+)*)"); // one or more keywords separated by whitespace
+    
 
     public ParserManager() {}
     
@@ -59,7 +58,7 @@ public class ParserManager {
             return new ClearCommand();
 
         case FindCommand.COMMAND_WORD:
-            return prepareFind(arguments);
+            return new SearchParser().prepare(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListParser().prepare(arguments);
@@ -109,23 +108,6 @@ public class ParserManager {
 
     }
 
-    /**
-     * Parses arguments in the context of the find person command.
-     *
-     * @param args full command args string
-     * @return the prepared command
-     */
-    private Command prepareFind(String args) {
-        final Matcher matcher = KEYWORDS_ARGS_FORMAT.matcher(args.trim());
-        if (!matcher.matches()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    FindCommand.MESSAGE_USAGE));
-        }
 
-        // keywords delimited by whitespace
-        final String[] keywords = matcher.group("keywords").split("\\s+");
-        final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
-        return new FindCommand(keywordSet);
-    }
 
 }

--- a/src/main/java/seedu/task/logic/parser/SearchParser.java
+++ b/src/main/java/seedu/task/logic/parser/SearchParser.java
@@ -1,0 +1,40 @@
+package seedu.task.logic.parser;
+
+import static seedu.taskcommons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.task.logic.commands.Command;
+import seedu.task.logic.commands.IncorrectCommand;
+import seedu.task.logic.commands.FindCommand;
+
+public class SearchParser implements Parser {
+	private static final Pattern KEYWORDS_ARGS_FORMAT =
+            Pattern.compile("(?<keywords>\\S+(?:\\s+\\S+)*)"); // one or more keywords separated by whitespace
+
+    /**
+     * Parses arguments in the context of the find person command.
+     *
+     * @param args full command args string
+     * @return the prepared command
+     */
+	@Override
+	public Command prepare(String args) {
+        final Matcher matcher = KEYWORDS_ARGS_FORMAT.matcher(args.trim());
+        if (!matcher.matches()) {
+            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    FindCommand.MESSAGE_USAGE));
+        }
+
+        // keywords delimited by whitespace
+        final String[] keywords = matcher.group("keywords").split("\\s+");
+        final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
+        return new FindCommand(keywordSet);
+		
+	}
+
+}

--- a/src/main/java/seedu/task/model/Model.java
+++ b/src/main/java/seedu/task/model/Model.java
@@ -47,6 +47,9 @@ public interface Model {
     /** Updates the filter of the filtered task list to filter by the given keywords*/
     void updateFilteredTaskList(Set<String> keywords);
     
+    /** Updates the filter of the filtered event list to filter by the given keywords*/
+    void updateFilteredEventList(Set<String> keywords);
+    
     /** Updates the filter of the filtered task list to filter by the status*/
     void updateFilteredTaskListToShowWithStatus(Boolean statusCompleted);
 

--- a/src/main/java/seedu/task/model/ModelManager.java
+++ b/src/main/java/seedu/task/model/ModelManager.java
@@ -128,6 +128,11 @@ public class ModelManager extends ComponentManager implements Model {
     }
     
     @Override
+    public void updateFilteredEventList(Set<String> keywords){
+        updateFilteredEventList(new PredicateExpression(new NameQualifier(keywords)));
+    }
+    
+    @Override
 	public void updateFilteredTaskListToShowWithStatus(Boolean status) {
 		updateFilteredTaskList(new PredicateExpression(new StatusQualifier(status)));
 		
@@ -199,7 +204,8 @@ public class ModelManager extends ComponentManager implements Model {
         @Override
         public boolean run(ReadOnlyTask task) {
             return taskKeyWords.stream()
-                    .filter(keyword -> StringUtil.containsIgnoreCase(task.getTask().fullName, keyword))
+                    .filter(keyword -> StringUtil.containsIgnoreCase(task.getTask().fullName, keyword) 
+                    		|| StringUtil.containsIgnoreCase(task.getDescription().value, keyword))
                     .findAny()
                     .isPresent();
         }
@@ -211,8 +217,11 @@ public class ModelManager extends ComponentManager implements Model {
 
 		@Override
 		public boolean run(ReadOnlyEvent event) {
-			// TODO Auto-generated method stub
-			return false;
+			return taskKeyWords.stream()
+                    .filter(keyword -> StringUtil.containsIgnoreCase(event.getEvent().fullName, keyword)
+                    		|| StringUtil.containsIgnoreCase(event.getDescription().value, keyword))
+                    .findAny()
+                    .isPresent();
 		}
     }
     

--- a/src/main/java/seedu/taskcommons/core/Messages.java
+++ b/src/main/java/seedu/taskcommons/core/Messages.java
@@ -10,5 +10,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
     public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX = "The event index provided is invalid";
     public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!";
+    public static final String MESSAGE_EVENTS_LISTED_OVERVIEW = "%1$d events listed!";
 
 }

--- a/src/test/java/guitests/ClearCommandTest.java
+++ b/src/test/java/guitests/ClearCommandTest.java
@@ -20,7 +20,7 @@ public class ClearCommandTest extends TaskBookGuiTest {
         commandBox.runCommand(td.arts.getAddCommand());
         assertTrue(taskListPanel.isListMatching(td.arts));
         commandBox.runCommand("delete 1");
-        assertListSize(0);
+        assertTaskListSize(0);
 
         //verify clear command works when the list is empty
         assertClearCommandSuccess();
@@ -28,7 +28,7 @@ public class ClearCommandTest extends TaskBookGuiTest {
 
     private void assertClearCommandSuccess() {
         commandBox.runCommand("clear");
-        assertListSize(0);
+        assertTaskListSize(0);
         assertResultMessage("Task book has been cleared!");
     }
 }

--- a/src/test/java/guitests/FindCommandTest.java
+++ b/src/test/java/guitests/FindCommandTest.java
@@ -3,43 +3,78 @@ package guitests;
 import org.junit.Test;
 
 import seedu.task.testutil.TestTask;
+import seedu.task.testutil.TypicalTestEvents;
+import seedu.task.testutil.TypicalTestTasks;
+import seedu.task.testutil.TestEvent;
+
 import seedu.taskcommons.core.Messages;
 
 import static org.junit.Assert.assertTrue;
+
+import java.util.List;
 
 import org.junit.Ignore;
 
 public class FindCommandTest extends TaskBookGuiTest {
 
-    @Ignore
-    @Test
-    public void find_nonEmptyList() {
-        assertFindResult("find cs2010"); //no results
-        assertFindResult("find cs10", td.cs1010, td.cs1020); //multiple results
 
+	@Test
+    public void find_nonEmptyList() {
+		//Tasks only
+        assertFindResultTask("find cs2010", 0, 0); //no results
+        
+        assertFindResultTask("find cs1010", 1, 0, TypicalTestTasks.cs1010); 
+        
+        assertFindResultTask("find Lecture 7", 2, 0, TypicalTestTasks.cs1010, TypicalTestTasks.cs1020); //multiple tasks result
+        
+        //Events only
+        assertFindResultEvent("find random", 0, 0); //no results
+        
+        assertFindResultEvent("find discussion", 0, 1, TypicalTestEvents.meeting3);
+        
+        assertFindResultEvent("find cs2103t", 0, 2, TypicalTestEvents.meeting1, TypicalTestEvents.meeting2); // two events
+        
+        //Both events and tasks
+        assertFindResultTask("find project", 2, 2, TypicalTestTasks.music, TypicalTestTasks.engine);
+        assertFindResultEvent("find project", 2, 2, TypicalTestEvents.meeting1, TypicalTestEvents.meeting2);
+        
         //find after deleting one result
-        commandBox.runCommand("delete 1");
-        assertFindResult("find cs10",td.cs1020);
+        commandBox.runCommand("delete -t 1");
+        assertFindResultTask("find my part", 1, 0, TypicalTestTasks.engine);
     }
 
-    @Ignore
+    
     @Test
     public void find_emptyList(){
         commandBox.runCommand("clear");
-        assertFindResult("find cs1010"); //no results
+        assertFindResultTask("find cs1010", 0, 0); //no results
     }
 
-    @Ignore
+
     @Test
     public void find_invalidCommand_fail() {
         commandBox.runCommand("findcs1010");
         assertResultMessage(Messages.MESSAGE_UNKNOWN_COMMAND);
     }
 
-    private void assertFindResult(String command, TestTask... expectedHits ) {
+    private void assertFindResultTask(String command,int tasksSize, int eventsSize, TestTask...expectedTasks) {
         commandBox.runCommand(command);
-        assertListSize(expectedHits.length);
-        assertResultMessage(expectedHits.length + " persons listed!");
-        assertTrue(taskListPanel.isListMatching(expectedHits));
+        
+        assertResultMessage(String.format(Messages.MESSAGE_TASKS_LISTED_OVERVIEW, tasksSize) + "\n" 
+                + String.format(Messages.MESSAGE_EVENTS_LISTED_OVERVIEW, eventsSize));
+        
+        assertTaskListSize(expectedTasks.length);
+        assertTrue(taskListPanel.isListMatching(expectedTasks));
+    }
+    
+    private void assertFindResultEvent(String command, int tasksSize, int eventsSize, TestEvent...expectedEvents) {
+
+    	commandBox.runCommand(command);
+        
+        assertResultMessage(String.format(Messages.MESSAGE_TASKS_LISTED_OVERVIEW, tasksSize) + "\n" 
+                + String.format(Messages.MESSAGE_EVENTS_LISTED_OVERVIEW, eventsSize));
+        
+        assertEventListSize(expectedEvents.length);
+        assertTrue(eventListPanel.isListMatching(expectedEvents));
     }
 }

--- a/src/test/java/guitests/SelectCommandTest.java
+++ b/src/test/java/guitests/SelectCommandTest.java
@@ -33,7 +33,7 @@ public class SelectCommandTest extends TaskBookGuiTest {
     @Test
     public void selectTask_emptyList(){
         commandBox.runCommand("clear");
-        assertListSize(0);
+        assertTaskListSize(0);
         assertSelectionInvalid(1); //invalid index
     }
 

--- a/src/test/java/guitests/TaskBookGuiTest.java
+++ b/src/test/java/guitests/TaskBookGuiTest.java
@@ -111,9 +111,17 @@ public abstract class TaskBookGuiTest {
     /**
      * Asserts the size of the task list is equal to the given number.
      */
-    protected void assertListSize(int size) {
-        int numberOfPeople = taskListPanel.getNumberOfTasks();
-        assertEquals(size, numberOfPeople);
+    protected void assertTaskListSize(int size) {
+        int numberOfTasks = taskListPanel.getNumberOfTasks();
+        assertEquals(size, numberOfTasks);
+    }
+    
+    /**
+     * Asserts the size of the event list is equal to the given number.
+     */
+    protected void assertEventListSize(int size) {
+        int numberOfEvents = eventListPanel.getNumberOfEvents();
+        assertEquals(size, numberOfEvents);
     }
 
     /**

--- a/src/test/java/guitests/guihandles/TaskListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/TaskListPanelHandle.java
@@ -48,6 +48,8 @@ public class TaskListPanelHandle extends GuiHandle {
         return this.isListMatching(0, tasks);
     }
     
+   
+    
     /**
      * Clicks on the ListView.
      */

--- a/src/test/java/seedu/task/testutil/TypicalTestEvents.java
+++ b/src/test/java/seedu/task/testutil/TypicalTestEvents.java
@@ -17,19 +17,19 @@ public class TypicalTestEvents {
 		try {
 			meeting1 = new EventBuilder()
 					.withName("ms v0")
-					.withDescription("for CS2103 project")
+					.withDescription("for CS2103t project")
 					.withDuration("yesterday 1pm > yesterday 2pm")
 					.build();
 			
 			meeting2 = new EventBuilder()
 					.withName("ms v1")
-					.withDescription("for CS2103 project")
+					.withDescription("for CS2103t project")
 					.withDuration("tomorrow 3pm > tomorrow 4pm")
 					.build();
 			
 			meeting3 = new EventBuilder()
 					.withName("ms v2")
-					.withDescription("for CS2103 project")
+					.withDescription("for CS2103 discussion")
 					.withDuration("tomorrow 8pm > tomorrow 11pm")
 					.build();
 		} catch (IllegalValueException e) {


### PR DESCRIPTION
### Context
- Behaviour: `find KEYWORD [MORE_KEYWORDS]` will find matching keywords in **both** name and descriptions of **both** events and tasks. **Completed** events and task will also be shown. 
### Links
#25
### Media

<img width="918" alt="screen shot 2016-10-14 at 02 10 43" src="https://cloud.githubusercontent.com/assets/11676094/19361009/7785d2bc-91b3-11e6-895e-c7e81b72b0ae.png">
### Reviewers

@CS2103AUG2016-F09-C4/developers 
