### PR TITLE
Improve Deadline format

### DIFF
--- a/src/main/java/seedu/task/commons/util/StringUtil.java
+++ b/src/main/java/seedu/task/commons/util/StringUtil.java
@@ -2,10 +2,17 @@ package seedu.task.commons.util;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
+
+import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
+
+import seedu.task.commons.exceptions.IllegalValueException;
 
 /**
  * Helper functions for handling strings.
@@ -15,6 +22,28 @@ public class StringUtil {
 	 * DateTimeFormatter for LocalTimeDate fields. 
 	 */
 	public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT);
+	private static final int DATE_INDEX = 0;
+	
+	/**
+	 * Parse a String argument into date format. 
+	 * @param parser
+	 * @param dateArg
+	 * @return date in LocalDateTime format
+	 * @throws IllegalValueException
+	 */
+	public static LocalDateTime parseStringToTime(String dateArg) throws IllegalValueException {
+		PrettyTimeParser parser = new PrettyTimeParser();
+		
+		//invalid start date
+		if(dateArg == null) throw new IllegalValueException(dateArg);
+		
+		List<Date> parsedResult = parser.parse(dateArg);
+		
+		//cannot parse
+		if(parsedResult.isEmpty()) throw new IllegalValueException(dateArg);
+		
+		return LocalDateTime.ofInstant(parsedResult.get(DATE_INDEX).toInstant(), ZoneId.systemDefault()); 
+	}
 	
     public static boolean containsIgnoreCase(String source, String query) {
         String[] split = source.toLowerCase().split("\\s+");

--- a/src/main/java/seedu/task/model/item/Deadline.java
+++ b/src/main/java/seedu/task/model/item/Deadline.java
@@ -1,6 +1,9 @@
 package seedu.task.model.item;
 
+import java.time.LocalDateTime;
+
 import seedu.task.commons.exceptions.IllegalValueException;
+import seedu.task.commons.util.StringUtil;
 
 
 /**
@@ -10,48 +13,66 @@ import seedu.task.commons.exceptions.IllegalValueException;
  */
 public class Deadline {
 
-    public static final String MESSAGE_DEADLINE_CONSTRAINTS = "Task deadline should be in a date format of DD-MM-YY";
-    public static final String DEADLINE_VALIDATION_REGEX = "(([0-9]{2})[-]([0-9]{2})[-]([0-9]{2}))?"; 
+    public static final String MESSAGE_DEADLINE_CONSTRAINTS = 
+    		"Task deadline can be in the following format: \n"
+    		+ "DAY HH:MM[:SS], eg: Monday 12:00[:30]\n"
+    		+ "M D Y, eg: Oct 12 2016\n"
+    		+ "M/D/Y, eg: 01/30/16\n"
+    		+ "RELATIVE_DAY TIME, tomorrow 4pm\n";
+    
 
-    public final String value;
+    private LocalDateTime deadLine; 
 
     /**
      * Validates given deadline.
      *
      * @throws IllegalValueException if given deadline string is invalid.
      */
-    public Deadline(String deadline) throws IllegalValueException {
-        assert deadline != null;
-        deadline = deadline.trim();
+    public Deadline(String deadlineArg) throws IllegalValueException {
+        assert deadlineArg != null;
+        deadlineArg = deadlineArg.trim();
    
-        if (!isValidDeadline(deadline)) {
-            throw new IllegalValueException(MESSAGE_DEADLINE_CONSTRAINTS);
+        try {
+        	this.deadLine = StringUtil.parseStringToTime(deadlineArg);
+        } catch (IllegalValueException e) {
+        	throw new IllegalValueException(MESSAGE_DEADLINE_CONSTRAINTS);
         }
-        this.value = deadline;
     }
 
-    /**
-     * Returns true if a given string is a valid task deadline.
-     */
-    public static boolean isValidDeadline(String test) {
-        return test.matches(DEADLINE_VALIDATION_REGEX);
-    }
 
     @Override
     public String toString() {
-        return value;
+        return this.deadLine.format(StringUtil.DATE_FORMATTER);
     }
 
     @Override
-    public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Deadline // instanceof handles nulls
-                && this.value.equals(((Deadline) other).value)); // state check
-    }
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((this.toString() == null) ? 0 : this.toString().hashCode());
+		return result;
+	}
 
-    @Override
-    public int hashCode() {
-        return value.hashCode();
-    }
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		
+		Deadline other = (Deadline) obj;
+		if (deadLine == null) {
+			if (other.deadLine != null)
+				return false;
+		} else if (!this.toString()
+				.equals(other.toString())) /*Standardized String to compare for equality */
+			return false;
+		return true;
+	}
+
+    
 
 }

--- a/src/main/java/seedu/task/model/item/EventDuration.java
+++ b/src/main/java/seedu/task/model/item/EventDuration.java
@@ -110,17 +110,8 @@ public class EventDuration {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
+		
 		EventDuration other = (EventDuration) obj;
-		if (endTime == null) {
-			if (other.endTime != null)
-				return false;
-		} else if (!endTime.equals(other.endTime))
-			return false;
-		if (startTime == null) {
-			if (other.startTime != null)
-				return false;
-		} else if (!startTime.equals(other.startTime))
-			return false;
-		return true;
+		return this.toString().equals(other.toString());
 	}
 }

--- a/src/main/java/seedu/task/model/item/EventDuration.java
+++ b/src/main/java/seedu/task/model/item/EventDuration.java
@@ -2,17 +2,11 @@ package seedu.task.model.item;
 
 import seedu.task.commons.exceptions.IllegalValueException;
 import seedu.task.commons.util.StringUtil;
-import java.time.Duration;
+
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.FormatStyle;
-import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
 
 /**
  * Represents an event's duration in the task book. Guarantees: immutable; is
@@ -45,54 +39,36 @@ public class EventDuration {
 		parseDuration(durationArg);
 	}
 
+	
 	private void parseDuration(String durationArg) throws IllegalValueException {
 		final Matcher matcher = DURATION_VALIDATION_REGEX.matcher(durationArg);
-		final PrettyTimeParser parser = new PrettyTimeParser();
+		if(!matcher.matches()) throw new IllegalValueException(MESSAGE_DURATION_CONSTRAINTS);
 		
-		if(matcher.matches()) {
-			//store the start date and end date 
-			Optional<String> startTimeArg = Optional.ofNullable(matcher.group("startTime"));
-			Optional<String> endTimeArg = Optional.ofNullable(matcher.group("endTime"));
+		//store the start date and end date 
+		Optional<String> startTimeArg = Optional.ofNullable(matcher.group("startTime"));
+		Optional<String> endTimeArg = Optional.ofNullable(matcher.group("endTime"));
 			
-			parseStartAndEndTime(startTimeArg, endTimeArg, parser);
-		} else {
+		try{
+			parseStartAndEndTime(startTimeArg, endTimeArg);
+		} catch (IllegalValueException e) {
 			throw new IllegalValueException(MESSAGE_DURATION_CONSTRAINTS);
 		}
+
 	}
 	
-	private void parseStartAndEndTime(Optional<String> startTimeArg, Optional<String> endTimeArg, PrettyTimeParser parser) throws IllegalValueException {
-		if(!startTimeArg.isPresent()) throw new IllegalValueException(MESSAGE_DURATION_CONSTRAINTS);
-
-		setStartTime(parseTime(parser, startTimeArg.get()));
+	private void parseStartAndEndTime(Optional<String> startTimeArg, Optional<String> endTimeArg) throws IllegalValueException {
+		if(!startTimeArg.isPresent()) throw new IllegalValueException(MESSAGE_DURATION_CONSTRAINTS); /* start time must not be empty */
+		
+		setStartTime(StringUtil.parseStringToTime(startTimeArg.get()));
 		assert getStartTime() != null;
 		
 		if(endTimeArg.isPresent()) {
-			setEndTime(parseTime(parser, endTimeArg.get()));
+			setEndTime(StringUtil.parseStringToTime(endTimeArg.get()));
 		} else {
-			setEndTime(getStartTime().plusHours(DEFAULT_DURATION));
+			setEndTime(getStartTime().plusHours(DEFAULT_DURATION)); /* if no end time, set default duration of event to 1 hr */
 		}
 		assert getEndTime() != null;
 	}
-
-	/**
-	 * Parse a String argument into date format. 
-	 * @param parser
-	 * @param dateArg
-	 * @return date in LocalDateTime format
-	 * @throws IllegalValueException
-	 */
-	private LocalDateTime parseTime(PrettyTimeParser parser, String dateArg) throws IllegalValueException {
-		//invalid start date
-		if(dateArg == null) throw new IllegalValueException(MESSAGE_DURATION_CONSTRAINTS);
-		
-		List<Date> parsedResult = parser.parse(dateArg);
-		
-		//cannot parse
-		if(parsedResult.isEmpty()) throw new IllegalValueException(MESSAGE_DURATION_CONSTRAINTS);
-		
-		return LocalDateTime.ofInstant(parsedResult.get(DATE_INDEX).toInstant(), ZoneId.systemDefault()); 
-	}
-	
 
 	public LocalDateTime getStartTime() {
 		return startTime;

--- a/src/test/java/seedu/task/logic/AddCommandTest.java
+++ b/src/test/java/seedu/task/logic/AddCommandTest.java
@@ -2,6 +2,7 @@ package seedu.task.logic;
 
 import static seedu.taskcommons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.List;
 import org.junit.Test;
 
 import seedu.task.logic.TestDataHelper;
@@ -17,21 +18,68 @@ import seedu.task.model.item.Task;
 
 public class AddCommandTest extends CommandTest{
 
+	
+	
     @Test
     public void execute_add_invalidArgsFormat() throws Exception {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
         assertCommandBehavior(
                 "add", expectedMessage);
+        
+        //empty deadline string
+        assertCommandBehavior(
+                "add validName /desc validDescription /by   ", expectedMessage);
     }
 
-    @Test
+
+    
+    /*
+	 * Possible EP of Valid Deadline 
+	 * 	 With the flexibility built-in the NLP parsing, the partition is not total. 
+	 * 	 - Relative dates phrases with numbers representing time
+	 * 	 - Numbers with or without ':' representing time, ie: 12:30:10 
+	 *   - M/D/Y with valid range of M, D
+	 *   - M/D with valid range of M, D
+	 *   - Number Day, ie: 2 Monday, meaning the Monday in 2 week's time.
+	 *   - Invalid words followed by number, ie: haha 1pm.
+	 *   
+	 * Possible EP of Invalid Deadline 
+	 * 	 - Phrases in abbreviation or not referring to  relative date.
+	 *   - Characters that are not related to date/time.
+	 *   - null
+	 *   - Empty String 
+	 *   
+	 * Due to the flexibility of prettytime library, the constrain on the deadline format will be looser.
+	 * We will not report invalid formats for deadlines, but provide elaborative feedback to users 
+	 * on the parsed result. 
+	 * 
+	 * Possible valid use cases:
+	 * 	 - DAY HH:MM
+	 * 	 - M/D[/Y]
+	 * 	 - RELATIVE_DAY TIME[pm|am]
+	 *   - NO_WEEKS_LATER DAY
+	 *   - DATE
+	 *   - DATE HHMM
+	 * 	
+	 * Possible invalid use cases:
+	 * 	 - RANDOM_WORD
+	 *   - INVALID_ABBREVIATION 
+	 */
+    @Test 
     public void execute_addTask_invalidTaskData() throws Exception {
-        assertCommandBehavior(
+    	//Invalid Name 
+    	assertCommandBehavior(
                 "add []\\[;] /desc nil /by 30-12-16", Name.MESSAGE_NAME_CONSTRAINTS);
         assertCommandBehavior(
                 "add []\\[;] /desc nil", Name.MESSAGE_NAME_CONSTRAINTS);
+        
+        //Invalid Deadline
         assertCommandBehavior(
-                "add Valid Name /desc nil /by 30-12-111", Deadline.MESSAGE_DEADLINE_CONSTRAINTS);
+                "add validName /desc validDesc /by randOmWord123", Deadline.MESSAGE_DEADLINE_CONSTRAINTS);
+        
+        //invalid abbreviation
+        assertCommandBehavior(
+                "add validName /desc validDesc /by Septem", Deadline.MESSAGE_DEADLINE_CONSTRAINTS);
     }
     
     @Test
@@ -50,19 +98,28 @@ public class AddCommandTest extends CommandTest{
     }
 
     @Test
-    public void execute_addTask_successful() throws Exception {
+    public void execute_addTaskWithDeadline_successful() throws Exception {
         // setup expectations
         TestDataHelper helper = new TestDataHelper();
-        Task toBeAdded = helper.computingTask();
+        
+        // different argument to cover use cases as mentioned above
+        Task tTarget1 = helper.generateTaskWithDeadline("Friday 11:01");
+        Task tTarget2 = helper.generateTaskWithDeadline("November 11");
+        Task tTarget3 = helper.generateTaskWithDeadline("next Friday 2pm");
+        Task tTarget4 = helper.generateTaskWithDeadline("2 Monday");
+        Task tTarget5 = helper.generateTaskWithDeadline("12/30/2016");
+        Task tTarget6 = helper.generateTaskWithDeadline("12/30/2016 11:12");
+        
         TaskBook expectedAB = new TaskBook();
-        expectedAB.addTask(toBeAdded);
-
-        // execute command and verify result
-        assertTaskCommandBehavior(helper.generateAddTaskCommand(toBeAdded),
-                String.format(AddTaskCommand.MESSAGE_SUCCESS, toBeAdded),
-                expectedAB,
-                expectedAB.getTaskList());
-
+        List<Task> targetList = helper.generateTaskList(tTarget1, tTarget2, tTarget3, tTarget4, tTarget5, tTarget6);
+        
+        for(Task target: targetList) {
+        	expectedAB.addTask(target);
+        	assertTaskCommandBehavior(helper.generateAddTaskCommand(target),
+                    String.format(AddTaskCommand.MESSAGE_SUCCESS, target),
+                    expectedAB,
+                    expectedAB.getTaskList());
+        }
     }
     
     @Test

--- a/src/test/java/seedu/task/logic/CommandTest.java
+++ b/src/test/java/seedu/task/logic/CommandTest.java
@@ -83,6 +83,7 @@ public class CommandTest extends LogicBasicTest {
         //Execute the command
         CommandResult result = logic.execute(inputCommand);
         
+        List<ReadOnlyTask> list = model.getFilteredTaskList();
         
         //Confirm the ui display elements should contain the right data
         assertEquals(expectedMessage, result.feedbackToUser);

--- a/src/test/java/seedu/task/logic/TestDataHelper.java
+++ b/src/test/java/seedu/task/logic/TestDataHelper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import seedu.task.commons.exceptions.IllegalValueException;
 import seedu.task.model.Model;
 import seedu.task.model.TaskBook;
 import seedu.task.model.item.Deadline;
@@ -359,6 +360,18 @@ class TestDataHelper{
     }
     
     /**
+     * Generates a task object with given deadline. Other fields will have some dummy values.
+     */
+	Task generateTaskWithDeadline(String deadline) throws IllegalValueException {
+		return new Task(
+				new Name("randomName"),
+				new Description("random description"),
+				new Deadline(deadline),
+				false
+				); 
+	}
+    
+    /**
      * Generates a Event object with given name. Other fields will have some dummy values.
      */
     Event generateEventWithNameAndDuration(String name, String duration) throws Exception {
@@ -368,4 +381,8 @@ class TestDataHelper{
                 new EventDuration(duration)
         );
     }
+
+    
+
+
 }

--- a/src/test/java/seedu/task/model/EventDurationTest.java
+++ b/src/test/java/seedu/task/model/EventDurationTest.java
@@ -1,0 +1,19 @@
+package seedu.task.model;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+import seedu.task.commons.exceptions.IllegalValueException;
+import seedu.task.model.item.EventDuration;
+
+public class EventDurationTest {
+
+	@Test
+	public void equal_noEndTime() throws IllegalValueException {
+		EventDuration e1 = new EventDuration("01-01-15");
+		EventDuration e2 = new EventDuration("01-01-15");
+		EventDuration e3 = new EventDuration("01-02-15");
+		
+		assertEquals(e1, e2);
+	}
+}


### PR DESCRIPTION
### Context
- add junit test for some valid/invalid deadline format. 
- update message
- restructure parseStringToTime method into StringUtil
  - In order to parse a String to a LocalDateTime, simply call `StringUtil.parseStringToTime`
- add TestDataHelper.generateTaskWithDeadline() method call. 
### Links

resolves #62 
### Reviewers

@CS2103AUG2016-F09-C4/developers 
