### PR TITLE
Implement edit event

### DIFF
--- a/src/main/java/seedu/task/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/task/logic/commands/EditEventCommand.java
@@ -1,0 +1,113 @@
+package seedu.task.logic.commands;
+
+import seedu.task.commons.exceptions.IllegalValueException;
+import seedu.task.model.item.Description;
+import seedu.task.model.item.Event;
+import seedu.task.model.item.EventDuration;
+import seedu.task.model.item.Name;
+import seedu.task.model.item.ReadOnlyEvent;
+import seedu.task.model.item.ReadOnlyTask;
+import seedu.task.model.item.Task;
+import seedu.task.model.item.UniqueEventList;
+import seedu.task.model.item.UniqueTaskList;
+import seedu.task.model.item.UniqueTaskList.DuplicateTaskException;
+import seedu.taskcommons.core.Messages;
+import seedu.taskcommons.core.UnmodifiableObservableList;
+
+/**
+ * Executes editing of events according to the input argument.
+ * @author kian ming
+ */
+public class EditEventCommand extends EditCommand {
+
+    public static final String MESSAGE_EDIT_EVENT_SUCCESS = "Edited Event: %1$s";
+    public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists in the task book";
+    
+    private Name newName;
+    private Description newDescription;
+    private EventDuration newDuration;
+    
+    private boolean isNameToBeEdit;
+    private boolean isDescriptionToBeEdit;
+    private boolean isDurationToBeEdit;
+    
+    /**
+     * Convenience constructor using raw values.
+     * Only fields to be edited will have values parsed in.
+     * Empty string parsed in otherwise.
+     *  
+     * @throws IllegalValueException
+     *             if any of the raw values are invalid
+     */
+    public EditEventCommand(Integer index,
+                           boolean isNameToBeEdited, String name, 
+                           boolean isDescriptionToBeEdited, String description,
+                           boolean isDurationToBeEdited, String duration
+                           ) throws IllegalValueException {
+        
+        setTargetIndex(index);
+        this.isNameToBeEdit = isNameToBeEdited;
+        this.isDescriptionToBeEdit = isDescriptionToBeEdited;
+        
+        newName = null;
+        newDescription = null;
+        newDuration = null;
+        
+        if (isNameToBeEdited) {
+            assert name != null && name != "";
+            newName = new Name(name);
+        } 
+        if (isDescriptionToBeEdited) {
+            assert description != null && description != "";
+            newDescription = new Description(description);
+        }
+        if (isDurationToBeEdited) {
+            assert duration != null && duration != "";
+            newDuration = new EventDuration(duration);
+        }
+    }
+    
+    /**
+     * Gets the event to be edited based on the index.
+     * Only fields to be edited will have values updated.
+     * @throws DuplicateTaskException 
+     */
+    @Override
+    public CommandResult execute() {
+        try {
+            
+            UnmodifiableObservableList<ReadOnlyEvent> lastShownList = model.getFilteredEventList();        
+            ReadOnlyEvent targetEvent = lastShownList.get(getTargetIndex());
+            
+            Event editEvent = editEvent(targetEvent);
+            model.editEvent(editEvent, targetEvent);
+            
+            return new CommandResult(String.format(MESSAGE_EDIT_EVENT_SUCCESS, editEvent));
+
+        } catch (UniqueEventList.DuplicateEventException e) {
+            return new CommandResult(MESSAGE_DUPLICATE_EVENT);
+        } catch (IndexOutOfBoundsException ie) {
+            indicateAttemptToExecuteIncorrectCommand();
+            return new CommandResult(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+        }
+    }
+
+    /**
+     * Edits the necessary fields.
+     * @return event that has the fields according to edit requirements.
+     */
+    private Event editEvent(ReadOnlyEvent targetEvent) {
+        assert targetEvent != null;
+        if (!isNameToBeEdit) {
+            newName = targetEvent.getEvent();
+        }
+        if (!isDescriptionToBeEdit) {
+            newDescription = targetEvent.getDescription();
+        }
+        if (!isDurationToBeEdit) {
+            newDuration = targetEvent.getDuration();
+        }
+        return new Event (this.newName, this.newDescription, this.newDuration);
+    }
+
+}

--- a/src/main/java/seedu/task/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/task/logic/commands/EditEventCommand.java
@@ -48,6 +48,7 @@ public class EditEventCommand extends EditCommand {
         setTargetIndex(index);
         this.isNameToBeEdit = isNameToBeEdited;
         this.isDescriptionToBeEdit = isDescriptionToBeEdited;
+        this.isDurationToBeEdit = isDurationToBeEdited;
         
         newName = null;
         newDescription = null;

--- a/src/main/java/seedu/task/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/task/logic/commands/EditTaskCommand.java
@@ -1,6 +1,7 @@
 package seedu.task.logic.commands;
 
 import seedu.task.commons.exceptions.IllegalValueException;
+import seedu.task.model.item.Deadline;
 import seedu.task.model.item.Description;
 import seedu.task.model.item.Name;
 import seedu.task.model.item.ReadOnlyTask;
@@ -22,10 +23,10 @@ public class EditTaskCommand extends EditCommand  {
     
     private Name newName;
     private Description newDescription;
-//    private Deadline newDeadline;
+    private Deadline newDeadline;
     private boolean isNameToBeEdit;
     private boolean isDescriptionToBeEdit;
-//    private boolean isDeadlineToBeEdit;
+    private boolean isDeadlineToBeEdit;
     
     /**
      * Convenience constructor using raw values.
@@ -38,13 +39,14 @@ public class EditTaskCommand extends EditCommand  {
      */
     public EditTaskCommand(Integer index,
                            boolean isNameToBeEdited, String name, 
-                           boolean isDescriptionToBeEdited, String description
-//                           boolean isDeadlineToBeEdited, String deadline
+                           boolean isDescriptionToBeEdited, String description,
+                           boolean isDeadlineToBeEdited, String deadline
                            ) throws IllegalValueException {
         
         setTargetIndex(index);
         this.isNameToBeEdit = isNameToBeEdited;
         this.isDescriptionToBeEdit = isDescriptionToBeEdited;
+        this.isDeadlineToBeEdit = isDeadlineToBeEdited;
         
         newName = null;
         newDescription = null;
@@ -54,6 +56,9 @@ public class EditTaskCommand extends EditCommand  {
         } 
         if (isDescriptionToBeEdited) {
             newDescription = new Description(description);
+        }
+        if (isDeadlineToBeEdited) {
+            newDeadline = new Deadline(deadline);
         }
     }
     
@@ -88,13 +93,23 @@ public class EditTaskCommand extends EditCommand  {
      * @return task that has the fields according to edit requirements.
      */    
     private Task editTask(ReadOnlyTask targetTask) {
+        
         if (!isNameToBeEdit) {
             newName = targetTask.getTask();
         }
         if (!isDescriptionToBeEdit) {
             newDescription = targetTask.getDescription();
         }
-        return new Task (this.newName, this.newDescription, TASK_DEFAULT_STATUS);
+        if (!isDeadlineToBeEdit) {
+            if (targetTask.getDeadline().isPresent()) {
+                newDeadline = targetTask.getDeadline().get();
+                return new Task (this.newName, this.newDescription, this.newDeadline, TASK_DEFAULT_STATUS);
+            } else {
+                return new Task (this.newName, this.newDescription, TASK_DEFAULT_STATUS);
+            }
+        } 
+        return new Task (this.newName, this.newDescription, this.newDeadline, TASK_DEFAULT_STATUS);
+        
     }
 
 }

--- a/src/main/java/seedu/task/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/task/logic/commands/EditTaskCommand.java
@@ -50,6 +50,7 @@ public class EditTaskCommand extends EditCommand  {
         
         newName = null;
         newDescription = null;
+        newDeadline = null;
         
         if (isNameToBeEdited) {
             newName = new Name(name);

--- a/src/main/java/seedu/task/logic/parser/EditParser.java
+++ b/src/main/java/seedu/task/logic/parser/EditParser.java
@@ -33,7 +33,7 @@ public class EditParser implements Parser {
             Pattern.compile("(?:-e)\\s(?<index>\\d*)"
                     + "(?<newname>(?: /name [^/]+)*)"
                     + "(?<newdescription>(?: /desc [^/]+)*)?"
-                    + "(?<duration>(?: /from [^/]+)*)?"
+                    + "(?<newduration>(?: /from [^/]+)*)?"
 
                     //+ "(?<newdeadline>(?: /by [^/]+))$"
                     );
@@ -70,8 +70,8 @@ public class EditParser implements Parser {
                         eventMatcher.group("newname").replaceFirst("/name","").trim(),
                         isFieldToBeEdited(eventMatcher.group("newdescription")),
                         eventMatcher.group("newdescription").replaceFirst("/desc", "").trim(),
-                        isFieldToBeEdited(eventMatcher.group("duration")),
-                        eventMatcher.group("duration").replaceFirst("/from", "").trim()
+                        isFieldToBeEdited(eventMatcher.group("newduration")),
+                        eventMatcher.group("newduration").replaceFirst("/from", "").trim()
                 );
             } catch (IllegalValueException ive) {
                 return new IncorrectCommand(ive.getMessage());

--- a/src/main/java/seedu/task/logic/parser/EditParser.java
+++ b/src/main/java/seedu/task/logic/parser/EditParser.java
@@ -6,14 +6,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.task.commons.exceptions.IllegalValueException;
-import seedu.task.logic.commands.AddEventCommand;
-import seedu.task.logic.commands.AddTaskCommand;
 import seedu.task.logic.commands.Command;
 import seedu.task.logic.commands.EditCommand;
+import seedu.task.logic.commands.EditEventCommand;
 import seedu.task.logic.commands.EditTaskCommand;
 import seedu.task.logic.commands.IncorrectCommand;
-import seedu.task.logic.commands.ListEventCommand;
-import seedu.task.logic.commands.ListTaskCommand;
 
 /**
  * Prepares EditTaskCommand or EditEventCommand according to the input argument.
@@ -30,9 +27,17 @@ public class EditParser implements Parser {
 
                     //+ "(?<newdeadline>(?: /by [^/]+))$"
                     );
+
+ // remember to trim 
+    private static final Pattern EDIT_EVENT_DATA_ARGS_FORMAT = // '/' forward slashes are reserved for delimiter prefixes
+            Pattern.compile("(?:-e)\\s(?<index>\\d*)"
+                    + "(?<newname>(?: /name [^/]+)*)"
+                    + "(?<newdescription>(?: /desc [^/]+)*)?"
+                    + "(?<duration>(?: /from [^/]+)*)?"
+
+                    //+ "(?<newdeadline>(?: /by [^/]+))$"
+                    );
     
-    private static final String TYPE_TASK = "-t";
-    private static final String TYPE_EVENT = "-e";
     
     /**
      * Parses arguments in the context of the edit command.
@@ -43,6 +48,7 @@ public class EditParser implements Parser {
     @Override
     public Command prepare(String args) {
         final Matcher taskMatcher = EDIT_TASK_DATA_ARGS_FORMAT.matcher(args.trim());
+        final Matcher eventMatcher = EDIT_EVENT_DATA_ARGS_FORMAT.matcher(args.trim());
         
         if (taskMatcher.matches()){
             try {
@@ -52,6 +58,20 @@ public class EditParser implements Parser {
                         taskMatcher.group("newname").replaceFirst("/name","").trim(),
                         isFieldToBeEdited(taskMatcher.group("newdescription")),
                         taskMatcher.group("newdescription").replaceFirst("/desc", "").trim()
+                );
+            } catch (IllegalValueException ive) {
+                return new IncorrectCommand(ive.getMessage());
+            }
+        } else if (eventMatcher.matches()){
+            try {
+                return new EditEventCommand(
+                        Integer.parseInt(eventMatcher.group("index").trim()),
+                        isFieldToBeEdited(eventMatcher.group("newname")),
+                        eventMatcher.group("newname").replaceFirst("/name","").trim(),
+                        isFieldToBeEdited(eventMatcher.group("newdescription")),
+                        eventMatcher.group("newdescription").replaceFirst("/desc", "").trim(),
+                        isFieldToBeEdited(eventMatcher.group("duration")),
+                        eventMatcher.group("duration").replaceFirst("/from", "").trim()
                 );
             } catch (IllegalValueException ive) {
                 return new IncorrectCommand(ive.getMessage());

--- a/src/main/java/seedu/task/logic/parser/EditParser.java
+++ b/src/main/java/seedu/task/logic/parser/EditParser.java
@@ -24,8 +24,7 @@ public class EditParser implements Parser {
             Pattern.compile("(?:-t)\\s(?<index>\\d*)"
                     + "(?<newname>(?: /name [^/]+)*)"
                     + "(?<newdescription>(?: /desc [^/]+)*)?"
-
-                    //+ "(?<newdeadline>(?: /by [^/]+))$"
+                    + "(?<newdeadline>(?: /by [^/]+)*)?"
                     );
 
  // remember to trim 
@@ -34,8 +33,6 @@ public class EditParser implements Parser {
                     + "(?<newname>(?: /name [^/]+)*)"
                     + "(?<newdescription>(?: /desc [^/]+)*)?"
                     + "(?<newduration>(?: /from [^/]+)*)?"
-
-                    //+ "(?<newdeadline>(?: /by [^/]+))$"
                     );
     
     
@@ -57,7 +54,9 @@ public class EditParser implements Parser {
                         isFieldToBeEdited(taskMatcher.group("newname")),
                         taskMatcher.group("newname").replaceFirst("/name","").trim(),
                         isFieldToBeEdited(taskMatcher.group("newdescription")),
-                        taskMatcher.group("newdescription").replaceFirst("/desc", "").trim()
+                        taskMatcher.group("newdescription").replaceFirst("/desc", "").trim(),
+                        isFieldToBeEdited(taskMatcher.group("newdeadline")),
+                        taskMatcher.group("newdeadline").replaceFirst("/by", "").trim()
                 );
             } catch (IllegalValueException ive) {
                 return new IncorrectCommand(ive.getMessage());

--- a/src/main/java/seedu/task/model/Model.java
+++ b/src/main/java/seedu/task/model/Model.java
@@ -35,6 +35,9 @@ public interface Model {
     /** Edits the given task */
     void editTask(Task editTask, ReadOnlyTask targetTask) throws UniqueTaskList.DuplicateTaskException;
     
+    /** Edits the given event */
+    void editEvent(Event editEvent, ReadOnlyEvent targetEvent) throws UniqueEventList.DuplicateEventException;
+    
     /** Marks the given task */
     void markTask(ReadOnlyTask target);
 

--- a/src/main/java/seedu/task/model/ModelManager.java
+++ b/src/main/java/seedu/task/model/ModelManager.java
@@ -128,12 +128,12 @@ public class ModelManager extends ComponentManager implements Model {
 
     @Override
     public UnmodifiableObservableList<ReadOnlyTask> getFilteredTaskList() {
-        return new UnmodifiableObservableList<>(filteredTasks);
+        return new UnmodifiableObservableList<>(this.filteredTasks);
     }
     
     @Override
     public UnmodifiableObservableList<ReadOnlyEvent> getFilteredEventList() {
-        return new UnmodifiableObservableList<>(filteredEvents);
+        return new UnmodifiableObservableList<>(this.filteredEvents);
     }
 
     @Override

--- a/src/main/java/seedu/task/model/ModelManager.java
+++ b/src/main/java/seedu/task/model/ModelManager.java
@@ -7,6 +7,7 @@ import seedu.task.model.item.Event;
 import seedu.task.model.item.ReadOnlyEvent;
 import seedu.task.model.item.ReadOnlyTask;
 import seedu.task.model.item.Task;
+import seedu.task.model.item.UniqueEventList;
 import seedu.task.model.item.UniqueEventList.DuplicateEventException;
 import seedu.task.model.item.UniqueEventList.EventNotFoundException;
 import seedu.task.model.item.UniqueTaskList;
@@ -112,6 +113,13 @@ public class ModelManager extends ComponentManager implements Model {
         taskBook.editTask(editTask, targetTask);
         updateFilteredTaskListToShowWithStatus(false);
         indicateTaskBookChanged();   
+    }
+    
+    @Override
+    public void editEvent(Event editEvent, ReadOnlyEvent targetEvent) throws UniqueEventList.DuplicateEventException {
+        taskBook.editEvent(editEvent, targetEvent);
+        updateFilteredEventListToShowWithStatus(false);
+        indicateTaskBookChanged(); 
     }
 
         

--- a/src/main/java/seedu/task/model/TaskBook.java
+++ b/src/main/java/seedu/task/model/TaskBook.java
@@ -91,6 +91,16 @@ public class TaskBook implements ReadOnlyTaskBook {
         }
     }
     
+    /**
+     * Edits an event in the task book.
+     *
+     * @throws UniqueEventList.DuplicateEventException if an equivalent event already exists.
+     */
+    public void editEvent(Event editEvent, ReadOnlyEvent targetEvent) throws UniqueEventList.DuplicateEventException {
+        events.edit(editEvent, targetEvent);
+        
+    }
+    
 //// task-level operations
 
     /**

--- a/src/main/java/seedu/task/model/item/UniqueEventList.java
+++ b/src/main/java/seedu/task/model/item/UniqueEventList.java
@@ -73,6 +73,21 @@ public class UniqueEventList implements Iterable<Event> {
         }
         return taskFoundAndDeleted;
     }
+    
+    /**
+     * Edits an event in the list.
+     *
+     * @throws DuplicateEventException if the edited event is a duplicate of an existing event in the list.
+     */
+    public void edit(Event toEdit, ReadOnlyEvent targetEvent) throws UniqueEventList.DuplicateEventException {
+        assert toEdit != null && targetEvent != null;
+        if (contains(toEdit)) {
+            throw new DuplicateEventException();
+        }
+        int index = internalList.indexOf(targetEvent);
+        internalList.set(index, toEdit); 
+    }
+
 
     public ObservableList<Event> getInternalList() {
         return internalList;

--- a/src/test/java/seedu/task/logic/CommandTest.java
+++ b/src/test/java/seedu/task/logic/CommandTest.java
@@ -107,7 +107,7 @@ public class CommandTest extends LogicBasicTest {
 
         //Execute the command
         CommandResult result = logic.execute(inputCommand);
-        List<ReadOnlyEvent> list = model.getFilteredEventList();
+        //List<ReadOnlyEvent> list = model.getFilteredEventList();
         //Confirm the ui display elements should contain the right data
         assertEquals(expectedMessage, result.feedbackToUser);
         assertEquals(expectedShownList, model.getFilteredEventList());
@@ -213,7 +213,6 @@ public class CommandTest extends LogicBasicTest {
         //Execute the edit command
         CommandResult result = logic.execute(inputCommand);
         
-        
         //Confirm the ui display elements should contain the right data
         assertEquals(expectedMessage, result.feedbackToUser);
         assertEquals(expectedShownList, model.getFilteredTaskList());
@@ -224,18 +223,46 @@ public class CommandTest extends LogicBasicTest {
     }
     
     /**
-     * Testing for editing task to duplicate
-     * Before executing edit command, executes the add command for 2 tasks and list command for tasks
+     * Before executing edit command, executes the add command and list command
      * and confirms that the result message is correct and
      * also confirms that the following three parts of the LogicManager object's state are as expected:<br>
      *      - the internal task book data are same as those in the {@code expectedTaskBook} <br>
      *      - the backing list shown by UI matches the {@code shownList} <br>
      *      - {@code expectedTaskBook} was saved to the storage file. <br>
      */
-    protected void assertEditTaskCommandBehavior(String addCommandInput, String addCommandInput2, String listCommandInput,
+    protected void assertEditEventCommandBehavior(String addCommandInput, String listCommandInput,
                                        String inputCommand, String expectedMessage,
                                        ReadOnlyTaskBook expectedTaskBook,
-                                       List<? extends ReadOnlyTask> expectedShownList) throws Exception {
+                                       List<? extends ReadOnlyEvent> expectedShownList) throws Exception {
+        
+        //Adds an event and lists the event
+        logic.execute(addCommandInput);
+        logic.execute(listCommandInput);
+        
+        //Execute the edit command
+        CommandResult result = logic.execute(inputCommand);
+        
+        //Confirm the ui display elements should contain the right data
+        assertEquals(expectedMessage, result.feedbackToUser);
+        assertEquals(expectedShownList, model.getFilteredEventList());
+
+        //Confirm the state of data (saved and in-memory) is as expected
+        assertEquals(expectedTaskBook, model.getTaskBook());
+        assertEquals(expectedTaskBook, latestSavedTaskBook);
+    }
+    
+    /**
+     * Testing for editing task or event to duplicate
+     * Before executing edit command, executes the add command for 2 tasks or events and list command for tasks or events
+     * and confirms that the result message is correct and
+     * also confirms that the following three parts of the LogicManager object's state are as expected:<br>
+     *      - the internal task book data are same as those in the {@code expectedTaskBook} <br>
+     *      - the backing list shown by UI matches the {@code shownList} <br>
+     *      - {@code expectedTaskBook} was saved to the storage file. <br>
+     */
+    protected void assertEditDuplicateCommandBehavior(String addCommandInput, String addCommandInput2, String listCommandInput,
+                                       String inputCommand, String expectedMessage,
+                                       ReadOnlyTaskBook expectedTaskBook) throws Exception {
         
         //Adds 2 tasks and lists the task
         logic.execute(addCommandInput);
@@ -248,7 +275,6 @@ public class CommandTest extends LogicBasicTest {
         
         //Confirm the ui display elements should contain the right data
         assertEquals(expectedMessage, result.feedbackToUser);
-        assertEquals(expectedShownList, model.getFilteredTaskList());
 
         //Confirm the state of data (saved and in-memory) is as expected
         assertEquals(expectedTaskBook, model.getTaskBook());

--- a/src/test/java/seedu/task/logic/EditCommandTest.java
+++ b/src/test/java/seedu/task/logic/EditCommandTest.java
@@ -3,14 +3,29 @@ package seedu.task.logic;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import seedu.task.logic.commands.EditCommand;
+import seedu.task.logic.commands.EditEventCommand;
 import seedu.task.logic.commands.EditTaskCommand;
 import seedu.task.model.TaskBook;
+import seedu.task.model.item.Event;
 import seedu.task.model.item.Task;
+import seedu.task.model.item.UniqueTaskList.DuplicateTaskException;
 import seedu.taskcommons.core.Messages;
 
 public class EditCommandTest extends CommandTest {
 
-    //Tests for editing floating tasks and tasks
+    /*
+     * Tests for editing floating tasks and tasks
+     */
+    
+    /*
+     * 1) Invalid Edit Task and Event Command EPs
+     *  - Editing a task to an existing task, DuplicateTaskException
+     *  - Editing an event to an existing event, DuplicateEventException
+     *  - Invalid edit command input
+     *  - Invalid edit task index input
+     *  - Invalid edit event index input
+     */
     
     @Test
     public void execute_editFloatTask_duplicate() throws Exception {
@@ -24,71 +39,48 @@ public class EditCommandTest extends CommandTest {
         Task toBeEdited = helper.computingFloatTask();
 
         // execute command and verify result
-        assertEditTaskCommandBehavior(helper.generateAddFloatTaskCommand(toBeAdded), helper.generateAddFloatTaskCommand(toBeAdded2),helper.generateListTaskCommand(),
-                helper.generateEditTaskCommand(toBeEdited,2),
+        assertEditDuplicateCommandBehavior(helper.generateAddFloatTaskCommand(toBeAdded), helper.generateAddFloatTaskCommand(toBeAdded2),helper.generateListTaskCommand(),
+                helper.generateEditFloatTaskCommand(toBeEdited,2),
                 String.format(EditTaskCommand.MESSAGE_DUPLICATE_TASK, toBeEdited),
-                expectedAB,
-                expectedAB.getTaskList());
+                expectedAB);
 
     }
-
+    
     @Test
-    public void execute_editFloatTask_name_desc_successful() throws Exception {
+    public void execute_editEvent_duplicate() throws Exception {
         // setup expectations
         TestDataHelper helper = new TestDataHelper();
-        Task toBeAdded = helper.computingTask();
+        Event toBeAdded = helper.computingUpComingEvent();
         TaskBook expectedAB = new TaskBook();
-        expectedAB.addTask(toBeAdded);
-        Task toBeEdited = helper.computingEditedFloatTask();
-        expectedAB.editTask(toBeEdited, toBeAdded);
+        expectedAB.addEvent(toBeAdded);
+        Event toBeAdded2 = helper.computingUpComingEvent2();
+        expectedAB.addEvent(toBeAdded2);
+        Event toBeEdited = helper.computingUpComingEvent();
 
         // execute command and verify result
-        assertEditTaskCommandBehavior(helper.generateAddTaskCommand(toBeAdded),helper.generateListTaskCommand(),
-                helper.generateEditTaskCommand(toBeEdited,1),
-                String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, toBeEdited),
-                expectedAB,
-                expectedAB.getTaskList());
+        assertEditDuplicateCommandBehavior(helper.generateAddEventCommand(toBeAdded), helper.generateAddEventCommand(toBeAdded2),helper.generateListEventCommand(),
+                helper.generateEditEventCommand(toBeEdited,2),
+                String.format(EditEventCommand.MESSAGE_DUPLICATE_EVENT, toBeEdited),
+                expectedAB);
 
     }
-
-
+    
     @Test
-    public void execute_editFloatTask_name_successful() throws Exception {
+    public void execute_invalidEditCommandInput() throws Exception {
         // setup expectations
+        TaskBook expectedAB = new TaskBook();
         TestDataHelper helper = new TestDataHelper();
         Task toBeAdded = helper.computingTask();
-        TaskBook expectedAB = new TaskBook();
         expectedAB.addTask(toBeAdded);
-        Task toBeEdited = helper.computingEditedNameFloatTask();
-        expectedAB.editTask(toBeEdited, toBeAdded);
-
+        String invalidEditCommand = "edit ajsdn 1";
+        
         // execute command and verify result
         assertEditTaskCommandBehavior(helper.generateAddTaskCommand(toBeAdded),helper.generateListTaskCommand(),
-                helper.generateEditTaskCommand(toBeEdited,1),
-                String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, toBeEdited),
+                invalidEditCommand,
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE),
                 expectedAB,
-                expectedAB.getTaskList());
-
-    }
-
-
-    @Test
-    public void execute_editTask_desc_successful() throws Exception {
-        // setup expectations
-        TestDataHelper helper = new TestDataHelper();
-        Task toBeAdded = helper.computingTask();
-        TaskBook expectedAB = new TaskBook();
-        expectedAB.addTask(toBeAdded);
-        Task toBeEdited = helper.computingEditedDescFloatTask();
-        expectedAB.editTask(toBeEdited, toBeAdded);
-
-        // execute command and verify result
-        assertEditTaskCommandBehavior(helper.generateAddTaskCommand(toBeAdded),helper.generateListTaskCommand(),
-                helper.generateEditTaskCommand(toBeEdited,1),
-                String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, toBeEdited),
-                expectedAB,
-                expectedAB.getTaskList());
-
+                expectedAB.getTaskList()); 
+        
     }
     
     @Test
@@ -102,10 +94,326 @@ public class EditCommandTest extends CommandTest {
 
         // execute command and verify result
         assertEditTaskCommandBehavior(helper.generateAddTaskCommand(toBeAdded),helper.generateListTaskCommand(),
-                helper.generateEditTaskCommand(toBeEdited,2),
+                helper.generateEditFloatTaskCommand(toBeEdited,2),
                 String.format(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX),
                 expectedAB,
                 expectedAB.getTaskList());
 
     }
+    
+    @Test
+    public void execute_editEvent_invalidIndex_unsuccessful() throws Exception {
+     // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Event toBeAdded = helper.computingUpComingEvent();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addEvent(toBeAdded);
+        Event toBeEdited = helper.computingUpComingEvent2();
+
+        // execute command and verify result
+        assertEditEventCommandBehavior(helper.generateAddEventCommand(toBeAdded),helper.generateListEventCommand(),
+                helper.generateEditEventCommand(toBeEdited,2),
+                String.format(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX),
+                expectedAB,
+                expectedAB.getEventList());
+
+    }
+    
+    /*
+     * 2) Valid edit float task command and successful execution EPs
+     * 
+     *  - Editing a floating task
+     *      -> Editing name
+     *      -> Editing description
+     *      -> Editing name and description
+     *      -> Adding deadline to change to deadline task
+     *      -> Editing all 3 fields
+     *      
+     */
+
+    //Editing float task name only
+    @Test
+    public void execute_editFloatTask_name_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Task toBeAdded = helper.computingFloatTask();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addTask(toBeAdded);
+        Task toBeEdited = helper.computingEditedNameFloatTask();
+        expectedAB.editTask(toBeEdited, toBeAdded);
+
+        // execute command and verify result
+        assertEditTaskCommandBehavior(helper.generateAddFloatTaskCommand(toBeAdded),helper.generateListTaskCommand(),
+                helper.generateEditFloatTaskCommand(toBeEdited,1),
+                String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getTaskList());
+
+    }
+    
+    //Editing float task desc only
+    @Test
+    public void execute_editFloatTask_desc_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Task toBeAdded = helper.computingFloatTask();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addTask(toBeAdded);
+        Task toBeEdited = helper.computingEditedDescFloatTask();
+        expectedAB.editTask(toBeEdited, toBeAdded);
+        
+
+        // execute command and verify result
+        assertEditTaskCommandBehavior(helper.generateAddFloatTaskCommand(toBeAdded),helper.generateListTaskCommand(),
+                helper.generateEditFloatTaskCommand(toBeEdited,1),
+                String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getTaskList());
+
+    }
+    
+    //Editing float task name and desc
+    @Test
+    public void execute_editFloatTask_name_desc_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Task toBeAdded = helper.computingFloatTask();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addTask(toBeAdded);
+        Task toBeEdited = helper.computingEditedFloatTask();
+        expectedAB.editTask(toBeEdited, toBeAdded);
+
+        // execute command and verify result
+        assertEditTaskCommandBehavior(helper.generateAddFloatTaskCommand(toBeAdded),helper.generateListTaskCommand(),
+                helper.generateEditFloatTaskCommand(toBeEdited,1),
+                String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getTaskList());
+
+    }
+    
+    //Adding deadline to float task
+    @Test
+    public void execute_editFloatTaskToDeadlineTask_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Task toBeAdded = helper.computingFloatTask();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addTask(toBeAdded);
+        Task toBeEdited = helper.computingTask();
+        expectedAB.editTask(toBeEdited, toBeAdded);
+
+        // execute command and verify result
+        assertEditTaskCommandBehavior(helper.generateAddFloatTaskCommand(toBeAdded),helper.generateListTaskCommand(),
+                helper.generateEditTaskCommand(toBeEdited,1),
+                String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getTaskList());
+
+    }
+    
+    /*
+     * 3) Valid edit task command and successful execution EPs
+     * 
+     *   - Editing a task
+     *      -> Editing name
+     *      -> Editing description
+     *      -> Editing deadline
+     *      -> Editing all 3 fields
+     *      -> Removing deadline to change to floating task
+     *      
+     */
+
+    //Editing name
+    @Test
+    public void execute_editTask_name_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Task toBeAdded = helper.computingTask();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addTask(toBeAdded);
+        Task toBeEdited = helper.computingEditedNameTask();
+        expectedAB.editTask(toBeEdited, toBeAdded);
+
+        // execute command and verify result
+        assertEditTaskCommandBehavior(helper.generateAddTaskCommand(toBeAdded),helper.generateListTaskCommand(),
+                helper.generateEditTaskCommand(toBeEdited,1),
+                String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getTaskList());
+
+    }
+    
+    //Editing description
+    @Test
+    public void execute_editTask_desc_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Task toBeAdded = helper.computingTask();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addTask(toBeAdded);
+        Task toBeEdited = helper.computingEditedDescTask();
+        expectedAB.editTask(toBeEdited, toBeAdded);
+
+        // execute command and verify result
+        assertEditTaskCommandBehavior(helper.generateAddTaskCommand(toBeAdded),helper.generateListTaskCommand(),
+                helper.generateEditTaskCommand(toBeEdited,1),
+                String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getTaskList());
+
+    }
+    
+    //Editing deadline
+    @Test
+    public void execute_editTask_deadline_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Task toBeAdded = helper.computingTask();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addTask(toBeAdded);
+        Task toBeEdited = helper.computingEditedDeadlineTask();
+        expectedAB.editTask(toBeEdited, toBeAdded);
+
+        // execute command and verify result
+        assertEditTaskCommandBehavior(helper.generateAddTaskCommand(toBeAdded),helper.generateListTaskCommand(),
+                helper.generateEditTaskCommand(toBeEdited,1),
+                String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getTaskList());
+
+    }
+    
+    //Editing all 3 fields
+    @Test
+    public void execute_editTask_all_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Task toBeAdded = helper.computingTask();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addTask(toBeAdded);
+        Task toBeEdited = helper.computingEditedTask();
+        expectedAB.editTask(toBeEdited, toBeAdded);
+
+        // execute command and verify result
+        assertEditTaskCommandBehavior(helper.generateAddTaskCommand(toBeAdded),helper.generateListTaskCommand(),
+                helper.generateEditTaskCommand(toBeEdited,1),
+                String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getTaskList());
+
+    }
+    
+    //Removing deadline to change to floating task
+    @Ignore
+    @Test
+    public void execute_editTask_remove_deadline_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Task toBeAdded = helper.computingTask();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addTask(toBeAdded);
+        Task toBeEdited = helper.computingFloatTask();
+        expectedAB.editTask(toBeEdited, toBeAdded);
+
+        // execute command and verify result
+        assertEditTaskCommandBehavior(helper.generateAddTaskCommand(toBeAdded),helper.generateListTaskCommand(),
+                helper.generateEditFloatTaskCommand(toBeEdited,1),
+                String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getTaskList());
+
+    }
+    
+    /*
+     * 4) Valid edit event command and successful execution EPs
+     * 
+     *   - Editing an event
+     *      -> Editing name
+     *      -> Editing description
+     *      -> Editing duration
+     *      -> Editing all 3 fields
+     *      
+     */
+    
+    //Editing name
+    @Test
+    public void execute_editEvent_name_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Event toBeAdded = helper.computingUpComingEvent();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addEvent(toBeAdded);
+        Event toBeEdited = helper.computingEditedNameUpComingEvent();
+        expectedAB.editEvent(toBeEdited, toBeAdded);
+
+        // execute command and verify result
+        assertEditEventCommandBehavior(helper.generateAddEventCommand(toBeAdded),helper.generateListEventCommand(),
+                helper.generateEditEventCommand(toBeEdited,1),
+                String.format(EditEventCommand.MESSAGE_EDIT_EVENT_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getEventList());
+
+    }
+    
+    //Editing description
+    @Test
+    public void execute_editEvent_desc_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Event toBeAdded = helper.computingUpComingEvent();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addEvent(toBeAdded);
+        Event toBeEdited = helper.computingEditedDescUpComingEvent();
+        expectedAB.editEvent(toBeEdited, toBeAdded);
+
+        // execute command and verify result
+        assertEditEventCommandBehavior(helper.generateAddEventCommand(toBeAdded),helper.generateListEventCommand(),
+                helper.generateEditEventCommand(toBeEdited,1),
+                String.format(EditEventCommand.MESSAGE_EDIT_EVENT_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getEventList());
+
+    }
+    
+    //Editing duration
+    @Test
+    public void execute_editEvent_duration_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Event toBeAdded = helper.computingUpComingEvent();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addEvent(toBeAdded);
+        Event toBeEdited = helper.computingEditedDurationUpComingEvent();
+        expectedAB.editEvent(toBeEdited, toBeAdded);
+
+        // execute command and verify result
+        assertEditEventCommandBehavior(helper.generateAddEventCommand(toBeAdded),helper.generateListEventCommand(),
+                helper.generateEditEventCommand(toBeEdited,1),
+                String.format(EditEventCommand.MESSAGE_EDIT_EVENT_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getEventList());
+
+    }
+    
+    //Editing all 3 fields
+    @Test
+    public void execute_editEvent_all_successful() throws Exception {
+        // setup expectations
+        TestDataHelper helper = new TestDataHelper();
+        Event toBeAdded = helper.computingUpComingEvent();
+        TaskBook expectedAB = new TaskBook();
+        expectedAB.addEvent(toBeAdded);
+        Event toBeEdited = helper.computingUpComingEvent2();
+        expectedAB.editEvent(toBeEdited, toBeAdded);
+
+        // execute command and verify result
+        assertEditEventCommandBehavior(helper.generateAddEventCommand(toBeAdded),helper.generateListEventCommand(),
+                helper.generateEditEventCommand(toBeEdited,1),
+                String.format(EditEventCommand.MESSAGE_EDIT_EVENT_SUCCESS, toBeEdited),
+                expectedAB,
+                expectedAB.getEventList());
+
+    }
+ 
 }

--- a/src/test/java/seedu/task/logic/EditCommandTest.java
+++ b/src/test/java/seedu/task/logic/EditCommandTest.java
@@ -10,6 +10,8 @@ import seedu.taskcommons.core.Messages;
 
 public class EditCommandTest extends CommandTest {
 
+    //Tests for editing floating tasks and tasks
+    
     @Test
     public void execute_editFloatTask_duplicate() throws Exception {
         // setup expectations

--- a/src/test/java/seedu/task/logic/TestDataHelper.java
+++ b/src/test/java/seedu/task/logic/TestDataHelper.java
@@ -27,6 +27,14 @@ class TestDataHelper{
         return new Task(name, des, deadline, false);
     }
     
+    Task computingEditedTask() throws Exception {
+        Name name = new Name("Do CS2106 Project");
+        Deadline deadline = new Deadline("02-02-16");
+        Description des = new Description("To post on Github");
+        
+        return new Task(name, des, deadline, false);
+    }
+    
     Task computingFloatTask() throws Exception {
         Name name = new Name("Do CS2103 Project");
         Description des = new Description("post on Github");
@@ -48,11 +56,35 @@ class TestDataHelper{
         return new Task(name, des, false);
     }
     
+    Task computingEditedNameTask() throws Exception {
+        Name name = new Name("Do CS2106 Project");
+        Deadline deadline = new Deadline("01-01-16");
+        Description des = new Description("post on Github");
+        
+        return new Task(name, des, deadline, false);
+    }
+    
     Task computingEditedDescFloatTask() throws Exception {
         Name name = new Name("Do CS2103 Project");
         Description des = new Description("To post on Github");
         
         return new Task(name, des, false);
+    }
+    
+    Task computingEditedDescTask() throws Exception {
+        Name name = new Name("Do CS2103 Project");
+        Deadline deadline = new Deadline("01-01-16");
+        Description des = new Description("To post on Github");
+        
+        return new Task(name, des, deadline, false);
+    }
+    
+    Task computingEditedDeadlineTask() throws Exception {
+        Name name = new Name("Do CS2103 Project");
+        Deadline deadline = new Deadline("02-02-16");
+        Description des = new Description("post on Github");
+        
+        return new Task(name, des, deadline, false);
     }
     
     Task completedTask() throws Exception {
@@ -67,6 +99,38 @@ class TestDataHelper{
         Name name = new Name("Attend CS2103 Workshop");
         Description des = new Description("post on Github");
         EventDuration dur = new EventDuration("tomorrow 3pm > tomorrow 4pm");
+        
+        return new Event(name, des, dur);
+    }
+    
+    Event computingEditedNameUpComingEvent() throws Exception {
+        Name name = new Name("Attend CS2106 Workshop");
+        Description des = new Description("post on Github");
+        EventDuration dur = new EventDuration("tomorrow 3pm > tomorrow 4pm");
+        
+        return new Event(name, des, dur);
+    }
+    
+    Event computingEditedDescUpComingEvent() throws Exception {
+        Name name = new Name("Attend CS2103 Workshop");
+        Description des = new Description("To post on Github");
+        EventDuration dur = new EventDuration("tomorrow 3pm > tomorrow 4pm");
+        
+        return new Event(name, des, dur);
+    }
+    
+    Event computingEditedDurationUpComingEvent() throws Exception {
+        Name name = new Name("Attend CS2103 Workshop");
+        Description des = new Description("post on Github");
+        EventDuration dur = new EventDuration("tomorrow 5pm > tomorrow 6pm");
+        
+        return new Event(name, des, dur);
+    }
+    
+    Event computingUpComingEvent2() throws Exception {
+        Name name = new Name("Attend CS2106 Workshop");
+        Description des = new Description("To post on Github");
+        EventDuration dur = new EventDuration("tomorrow 7pm > tomorrow 8pm");
         
         return new Event(name, des, dur);
     }
@@ -124,6 +188,7 @@ class TestDataHelper{
     
     /** Generates the correct add task command based on the task given */
     String generateAddFloatTaskCommand(Task p) {
+        
         StringBuffer cmd = new StringBuffer();
 
         cmd.append("add ");
@@ -148,12 +213,36 @@ class TestDataHelper{
     }
     
     /** Generates the correct edit task command based on the new description string given */
+    String generateEditFloatTaskCommand(Task p, int index) {
+        StringBuffer cmd = new StringBuffer();
+
+        cmd.append("edit -t " + index);
+        cmd.append(" /name ").append(p.getTask().toString());
+        cmd.append(" /desc ").append(p.getDescription().toString());
+
+        return cmd.toString();
+    }
+    
+    /** Generates the correct edit task command based on the new description string given */
     String generateEditTaskCommand(Task p, int index) {
         StringBuffer cmd = new StringBuffer();
 
         cmd.append("edit -t " + index);
         cmd.append(" /name ").append(p.getTask().toString());
         cmd.append(" /desc ").append(p.getDescription().toString());
+        cmd.append(" /by ").append(p.getDeadline().get().toString());
+
+        return cmd.toString();
+    }
+    
+    /** Generates the correct edit event command based on the new description string given */
+    String generateEditEventCommand(Event p, int index) {
+        StringBuffer cmd = new StringBuffer();
+
+        cmd.append("edit -e " + index);
+        cmd.append(" /name ").append(p.getEvent().toString());
+        cmd.append(" /desc ").append(p.getDescription().toString());
+        cmd.append(" /from ").append(p.getDuration().toString());
 
         return cmd.toString();
     }
@@ -167,6 +256,15 @@ class TestDataHelper{
         return cmd.toString();
     }
 
+    /** Generates the correct list event */
+    String generateListEventCommand() {
+        StringBuffer cmd = new StringBuffer();
+
+        cmd.append("list -e");
+
+        return cmd.toString();
+    }
+    
     /**
      * Generates an TaskBook with auto-generated tasks.
      */

--- a/src/test/java/seedu/task/model/DeadlineTest.java
+++ b/src/test/java/seedu/task/model/DeadlineTest.java
@@ -1,0 +1,25 @@
+package seedu.task.model;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import seedu.task.commons.exceptions.IllegalValueException;
+import seedu.task.model.item.Deadline;
+
+public class DeadlineTest {
+
+    @Test
+    public void deadline_check() throws IllegalValueException {
+        Deadline d1 = new Deadline("01-01-15");
+        Deadline d2 = new Deadline("01-01-15");
+        Deadline d3 = new Deadline("01-02-15");
+        Deadline d4 = null;
+
+        assertEquals(d1,d2);
+        assertFalse(d1 == d3);
+        assertFalse(d1 == d4);
+        
+    }
+
+}


### PR DESCRIPTION
### Context

Implemented edit event
- Organised test cases for EditCommand to demonstrate Equivalence Partition
- Added test cases for edit event
- Fixed bugs restricting editing of deadline task and floating task
- Passed all tests
- There is an ignored test case which considers removing a deadline task's deadline, refer to next section
### To Discuss

While doing EP for editing tasks, I realised we didnt have a way for user to remove deadline for a deadline task, in case he/she wants to change the task to a floating task. How should we implement this? Eg. "edit -t 1 /by remove"?
### Links

Here you should add links that are related to this Pull Request. For example:
- #54 
### Reviewers

@CS2103AUG2016-F09-C4/developers 
